### PR TITLE
Replicate react card style in flutter

### DIFF
--- a/CARD_FLUTTER.DART
+++ b/CARD_FLUTTER.DART
@@ -97,7 +97,7 @@ class _EmployeeCardState extends State<EmployeeCard>
                 child: Container(
                   decoration: BoxDecoration(
                     color: baseblue, // Solid baseblue background
-                    borderRadius: BorderRadius.circular(16),
+                    borderRadius: BorderRadius.circular(10),
                   ),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -149,13 +149,13 @@ class _EmployeeCardState extends State<EmployeeCard>
                   child: Container(
                     decoration: BoxDecoration(
                       color: Colors.white,
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: BorderRadius.circular(10),
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.grey.withOpacity(0.2),
-                          spreadRadius: 1,
-                          blurRadius: 12,
-                          offset: const Offset(0, 4),
+                          color: Colors.black.withOpacity(0.15),
+                          spreadRadius: 0,
+                          blurRadius: 8,
+                          offset: const Offset(0, 3),
                         ),
                       ],
                     ),


### PR DESCRIPTION
Mirror React card styling in Flutter by adjusting border radius and box shadow.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b209fd1-8d6d-4622-ac1a-950a1d71ff17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b209fd1-8d6d-4622-ac1a-950a1d71ff17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

